### PR TITLE
Change health check to fail on absolute link paths on osx

### DIFF
--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -448,10 +448,28 @@ module Omnibus
         safe ||= true if reg.match(current_library)
       end
 
+      case Ohai["platform"]
+      when "mac_os_x"
+          # Relative executable paths paths are fine
+          if linked =~ %r{@executable_path/../lib}
+            safe ||= true
+          end
+
+          # If the library has a link with a hardcoded absolute path, then fail this dependency
+          if linked =~ Regexp.new(project.install_dir)
+            safe ||= false
+          end
+      else
+        # Only allow libraries which are imported via the project's install dir
+        if linked !~ Regexp.new(project.install_dir)
+          safe ||= false
+        end
+      end
+
       log.debug(log_key) { "  --> Dependency: #{name}" }
       log.debug(log_key) { "  --> Provided by: #{linked}" }
 
-      if !safe && linked !~ Regexp.new(project.install_dir)
+      if !safe
         log.debug(log_key) { "    -> FAILED: #{current_library} has unsafe dependencies" }
         bad_libs[current_library] ||= {}
         bad_libs[current_library][name] ||= {}

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -448,25 +448,19 @@ module Omnibus
         safe ||= true if reg.match(current_library)
       end
 
-      if project.require_relative_links
+      if project.require_portable_links
         case Ohai["platform"]
         when "mac_os_x"
-          # Relative executable paths paths are fine
           if linked =~ %r{@executable_path/../lib}
             safe ||= true
           end
-
-          # If the library has a link with a hardcoded absolute path, then fail this dependency
-          if linked =~ Regexp.new(project.install_dir)
-            safe ||= false
-          end
         else
-          raise HealthCheckFailed, "Platform #{Ohai["platform"]} does not support require_relative_links healthchecks"
+          raise HealthCheckFailed, "Platform #{Ohai["platform"]} does not support require_portable_links healthchecks"
         end
       else
         # Only allow libraries which are imported via the project's install dir
-        if linked !~ Regexp.new(project.install_dir)
-          safe ||= false
+        if linked =~ Regexp.new(project.install_dir)
+          safe ||= true
         end
       end
 

--- a/lib/omnibus/health_check.rb
+++ b/lib/omnibus/health_check.rb
@@ -448,8 +448,9 @@ module Omnibus
         safe ||= true if reg.match(current_library)
       end
 
-      case Ohai["platform"]
-      when "mac_os_x"
+      if project.require_relative_links
+        case Ohai["platform"]
+        when "mac_os_x"
           # Relative executable paths paths are fine
           if linked =~ %r{@executable_path/../lib}
             safe ||= true
@@ -459,6 +460,9 @@ module Omnibus
           if linked =~ Regexp.new(project.install_dir)
             safe ||= false
           end
+        else
+          raise HealthCheckFailed, "Platform #{Ohai["platform"]} does not support require_relative_links healthchecks"
+        end
       else
         # Only allow libraries which are imported via the project's install dir
         if linked !~ Regexp.new(project.install_dir)

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -422,7 +422,7 @@ module Omnibus
     expose :build_iteration
 
     #
-    # Signal that we're building software with relative links
+    # Signal that we're building software with portable links
     #
     # @example
     #   fast_msi true
@@ -431,14 +431,14 @@ module Omnibus
     #   whether the healthcheck enforces relative links
     #
     # @return [TrueClass, FalseClass]
-    #   whether the healthcheck enforces relative links
-    def require_relative_links(val = false)
+    #   whether the healthcheck enforces portable links
+    def require_portable_links(val = false)
       unless val.is_a?(TrueClass) || val.is_a?(FalseClass)
-        raise InvalidValue.new(:require_relative_links, "be TrueClass or FalseClass")
+        raise InvalidValue.new(:require_portable_links, "be TrueClass or FalseClass")
       end
-      @require_relative_links ||= val
+      @require_portable_links ||= val
     end
-    expose :require_relative_links
+    expose :require_portable_links
 
     #
     # Add or override a customization for the packager with the given +id+. When

--- a/lib/omnibus/project.rb
+++ b/lib/omnibus/project.rb
@@ -422,6 +422,25 @@ module Omnibus
     expose :build_iteration
 
     #
+    # Signal that we're building software with relative links
+    #
+    # @example
+    #   fast_msi true
+    #
+    # @param [TrueClass, FalseClass] value
+    #   whether the healthcheck enforces relative links
+    #
+    # @return [TrueClass, FalseClass]
+    #   whether the healthcheck enforces relative links
+    def require_relative_links(val = false)
+      unless val.is_a?(TrueClass) || val.is_a?(FalseClass)
+        raise InvalidValue.new(:require_relative_links, "be TrueClass or FalseClass")
+      end
+      @require_relative_links ||= val
+    end
+    expose :require_relative_links
+
+    #
     # Add or override a customization for the packager with the given +id+. When
     # given multiple blocks with the same +id+, they are evaluated _in order_,
     # so the last block evaluated will take precedence over the previous ones.

--- a/spec/unit/project_spec.rb
+++ b/spec/unit/project_spec.rb
@@ -31,6 +31,7 @@ module Omnibus
     it_behaves_like "a cleanroom setter", :conflict, %{conflict 'puppet'}
     it_behaves_like "a cleanroom setter", :build_version, %{build_version '1.2.3'}
     it_behaves_like "a cleanroom setter", :build_iteration, %{build_iteration 1}
+    it_behaves_like "a cleanroom setter", :require_portable_links, %{require_portable_links true}
     it_behaves_like "a cleanroom setter", :package_user, %{package_user 'chef'}
     it_behaves_like "a cleanroom setter", :package_group, %{package_group 'chef'}
     it_behaves_like "a cleanroom setter", :override, %{override :chefdk, source: 'foo.com'}
@@ -72,6 +73,10 @@ module Omnibus
 
       it "returns a build iteration" do
         expect(subject.build_iteration).to eq(1)
+      end
+
+      it "returns a require_portable_links flag" do
+        expect(subject.require_portable_links).to eq(false)
       end
 
       it "returns an array of files and dirs" do
@@ -240,6 +245,19 @@ module Omnibus
         it "returns a generic iteration" do
           expect(subject.build_iteration).to eq(1)
         end
+      end
+    end
+
+    describe "#require_portable_links" do
+      it "requires the value to be a TrueClass or a FalseClass" do
+        expect do
+          subject.require_portable_links(Object.new)
+        end.to raise_error(InvalidValue)
+      end
+
+      it "returns the given value" do
+        subject.require_portable_links(true)
+        expect(subject.require_portable_links).to be_truthy
       end
     end
 


### PR DESCRIPTION
### Description

This pull request changes the health check mechanism for omnibus, as part of the effort of running msfconsole at arbitrary locations - https://github.com/rapid7/metasploit-omnibus/pull/127

The current implementation could not be landed in its current form upstream, the current implementation is too specific to our use case.

#### Before

Omibus verifies that all osx build libs are either whitelisted files, or that their links match the project's root dir.

For instance, an example of a happy path lib. There is a reference directly to `/opt/metasploit-framework` - the project install dir.

```
/opt/metasploit-framework/embedded/bin/ruby:
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 57337.60.9)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1259.32.0)
--->	/opt/metasploit-framework/embedded/lib/libruby.2.6.dylib (compatibility version 2.6.0, current version 2.6.6)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0
```

Unfortunately the current check does not correctly handle the scenario of `@executable_path` being present in linked files:

```
/opt/metasploit-framework/embedded/bin/ruby:
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 57337.60.9)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1259.32.0)
--->	@executable_path/../lib/libruby.2.6.dylib (compatibility version 2.6.0, current version 2.6.6)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1226.10.1)
--->	@executable_path/../lib/libjemalloc.2.dylib (compatibility version 0.0.0, current version 0.0.0)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
```

Example Healthcheck failure:

```
    --> /opt/metasploit-framework//embedded/lib/libruby.2.6.dylib
    DEPENDS ON: libruby.2.6.dylib
      COUNT: 1
      PROVIDED BY: @executable_path/../lib/libruby.2.6.dylib
      FAILED BECAUSE: Unsafe dependency
    --> /opt/metasploit-framework//embedded/lib/libruby.2.6.dylib
    DEPENDS ON: libjemalloc.2.dylib
      COUNT: 1
      PROVIDED BY: @executable_path/../lib/libjemalloc.2.dylib
      FAILED BECAUSE: Unsafe dependency
```

#### After

Two changes have been made for osx omnibus builds:

- The healthcheck has now been updated to add a whitelist of `@executable_path` to linked files
- Any absolute paths to the project's install dir is now considered a failing health check.

--------------------------------------------------

#### Maintainers

Please ensure that you check for:

- [] If this change impacts git cache validity, it bumps the git cache
  serial number
- [] If this change impacts compatibility with omnibus-software, the
  corresponding change is reviewed and there is a release plan
- [] If this change impacts compatibility with the omnibus cookbook, the
  corresponding change is reviewed and there is a release plan
